### PR TITLE
timezone api check adjustment for upgrade advisor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -209,7 +209,7 @@ class UpgradeAdvisor {
             return UpgradeAdvisor::getState(false, "Your Google Maps API key came back with the following error. " . $googleapi_setttings->errorMessage. " Please make sure you have the 'Google Maps Geocoding API' enabled and that the API key is entered properly and has no referer restrictions. You can check your key at the Google API console here: https://console.cloud.google.com/apis/");
         }
 
-        $timezone_settings = json_decode(get($GLOBALS['timezone_lookup_endpoint'] . "&address=91409"));
+        $timezone_settings = json_decode(get($GLOBALS['timezone_lookup_endpoint'] . "&location=34.2011137,-118.475058&timestamp=" . time()));
 
         if ($timezone_settings->status == "REQUEST_DENIED") {
             return UpgradeAdvisor::getState(false, "Your Google Maps API key came back with the following error. " . $timezone_settings->errorMessage. " Please make sure you have the 'Google Maps Geocoding API' enabled and that the API key is entered properly and has no referer restrictions. You can check your key at the Google API console here: https://console.cloud.google.com/apis/");


### PR DESCRIPTION
this would have come back with INVALID_REQUEST as not up to proper api usage for timezone. this will do a timezone lookup for lat 34.2011137 long -118.475058, which are for zip 91409 (naws zip). if key is invalid it will now return with REQUEST_DENIED thus properly checking key for timezone api.