### PR TITLE
googleapi error message json slightly different between timezone & Geocode

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -206,7 +206,7 @@ class UpgradeAdvisor {
         $googleapi_settings = json_decode(get($GLOBALS['google_maps_endpoint'] . "&address=91409"));
 
         if ($googleapi_settings->status == "REQUEST_DENIED") {
-            return UpgradeAdvisor::getState(false, "Your Google Maps API key came back with the following error. " . $googleapi_settings->errorMessage. " Please make sure you have the 'Google Maps Geocoding API' enabled and that the API key is entered properly and has no referer restrictions. You can check your key at the Google API console here: https://console.cloud.google.com/apis/");
+            return UpgradeAdvisor::getState(false, "Your Google Maps API key came back with the following error. " . $googleapi_settings->error_message. " Please make sure you have the 'Google Maps Geocoding API' enabled and that the API key is entered properly and has no referer restrictions. You can check your key at the Google API console here: https://console.cloud.google.com/apis/");
         }
 
         $timezone_settings = json_decode(get($GLOBALS['timezone_lookup_endpoint'] . "&location=34.2011137,-118.475058&timestamp=" . time()));


### PR DESCRIPTION
you can see this here. Time Zone API json error response is "errorMessage" where as Geocode API json error response is "error_message"

https://maps.googleapis.com/maps/api/timezone/json?key=API_Key&location=30.1671932,-94.0082563&timestamp=1538612773

https://maps.googleapis.com/maps/api/geocode/json?key=API_KEY&address=77662

