### PR TITLE
default lookup bias fix

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,7 @@
 
 ### 2.3.3 (Unreleased)
 * Fix for dealing with bad input as a result of voice recognition on IVR inputs [#155]
+* Bug fix for location lookup bias
 
 ### 2.3.2 (October 2, 2018)
 * Hotfix for broken SMS sending of meeting list information due to a Twilio bug. [#150]

--- a/functions.php
+++ b/functions.php
@@ -19,7 +19,7 @@ static $settings_whitelist = [
     'jft_option' => [ 'description' => '' , 'default' => false, 'overridable' => true],
     'language' => [ 'description' => '' , 'default' => 'en', 'overridable' => true],
     'language_selections' => [ 'description' => '', 'default' => '', 'overridable' => true],
-    'location_lookup_bias' => [ 'description' => '' , 'default' => 'components=country:us', 'overridable' => true],
+    'location_lookup_bias' => [ 'description' => '' , 'default' => 'country:us', 'overridable' => true],
     'meeting_search_radius' => [ 'description' => '' , 'default' => -50, 'overridable' => true],
     'postal_code_length' => [ 'description' => '' , 'default' => 5, 'overridable' => true],
     'province_lookup' => [ 'description' => '' , 'default' => false, 'overridable' => true],


### PR DESCRIPTION
redundant use of components=  as this is already specified in the getCoordinatesForAddress function.

https://github.com/radius314/yap/blob/b3aec2b2b63bc1d93e994e952325efde3e2787cf/functions.php#L347-L350