### PR TITLE
fix for page build warning using external theme 

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     rouge (3.3.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.7.0)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,7 +17,7 @@ title: Yap
 description: Yap Documentation
 baseurl:
 url: "//yap.bmlt.app"
-theme: just-the-docs
+remote_theme: "pmarsceill/just-the-docs"
 sass:
   # Load dependancies
   load_paths:


### PR DESCRIPTION
https://blog.github.com/2017-11-29-use-any-theme-with-github-pages/